### PR TITLE
feat: manually specifiable branch names

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26518,7 +26518,7 @@ async function getPagesProject() {
 }
 async function createPagesDeployment(isProd) {
   const branch = config.branch || githubBranch;
-  const branchName = isProd || prBranchOwner === void 0 ? branch : `${prBranchOwner}-${branch}`;
+  const branchName = isProd || config.branch || prBranchOwner === void 0 ? branch : `${prBranchOwner}-${branch}`;
   await src_default.in(import_node_path.default.join(process.cwd(), config.workingDirectory))`
 $ export CLOUDFLARE_API_TOKEN="${config.apiToken}"
 if ${config.accountId} {

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -29,7 +29,8 @@ export async function getPagesProject() {
 
 export async function createPagesDeployment(isProd: boolean) {
 	const branch = config.branch || githubBranch;
-	const branchName = isProd || prBranchOwner === undefined ? branch : `${prBranchOwner}-${branch}`;
+	const branchName =
+		isProd || config.branch || prBranchOwner === undefined ? branch : `${prBranchOwner}-${branch}`;
 
 	// TODO: Replace this with an API call to wrangler so we can get back a full deployment response object
 	await shellac.in(path.join(process.cwd(), config.workingDirectory))`


### PR DESCRIPTION
When the `branch` input is set, it will now _always_ be used as the name of the branch.

For instance, if the config was as follows:
```yaml
directory: '...'
deploymentName: Preview
branch: preview
```
the domain for the deployment will be: `preview.project-name.pages.dev`.

---

Incases of PRs and forked PRs, you'd likely want to omit the `branch` input so that previews can have unique inferred names:
```yaml
directory: '...'
deploymentName: Preview
```
the domain for the deployment will be: `USERNAME-BRANCH_NAME.project-name.pages.dev`.