### PR TITLE
fix: PR deployment on matching prod branch name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26518,7 +26518,7 @@ async function getPagesProject() {
 }
 async function createPagesDeployment(isProd) {
   const branch = config.branch || githubBranch;
-  const branchName = config.branch ? config.branch : isProd || prBranchOwner === void 0 ? branch : `${prBranchOwner}-${branch}`;
+  const branchName = config.branch || isProd && isPR === false ? branch : `${prBranchOwner}-${branch}`;
   await src_default.in(import_node_path.default.join(process.cwd(), config.workingDirectory))`
 $ export CLOUDFLARE_API_TOKEN="${config.apiToken}"
 if ${config.accountId} {

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -2,7 +2,7 @@ import shellac from 'shellac';
 import path from 'node:path';
 import { fetch } from 'undici';
 import { config } from './config.js';
-import { githubBranch, prBranchOwner } from './globals.js';
+import { githubBranch, isPR, prBranchOwner } from './globals.js';
 import type { Deployment, Project } from '@cloudflare/types';
 
 export async function getPagesProject() {
@@ -29,12 +29,10 @@ export async function getPagesProject() {
 
 export async function createPagesDeployment(isProd: boolean) {
 	const branch = config.branch || githubBranch;
-	// use `config.branch` if it's set, otherwise, infer the name
-	const branchName = config.branch
-		? config.branch
-		: isProd || prBranchOwner === undefined
-			? branch
-			: `${prBranchOwner}-${branch}`;
+
+	// use `config.branch` if it's set or if we're in prod, otherwise infer the name
+	const branchName =
+		config.branch || (isProd && isPR === false) ? branch : `${prBranchOwner}-${branch}`;
 
 	// TODO: Replace this with an API call to wrangler so we can get back a full deployment response object
 	await shellac.in(path.join(process.cwd(), config.workingDirectory))`


### PR DESCRIPTION
Fixes an issue where if the PR's branch name matches the name of the production branch, then the preview deployment would deploy to that branch.